### PR TITLE
Refactor make step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -145,7 +145,6 @@ const ExampleStep = struct {
             \\  Flags:     
         ;
         print(fmt, .{ bold_ul, reset, b.graph.zig_exe, cmd, src_display, target, optimize });
-        for (argv.items[7..]) |arg| print("{s} ", .{arg});
         if (example.extra_args) |args| {
             for (args) |arg| print("{s} ", .{arg});
         }


### PR DESCRIPTION
I know I literally just changed the `make()` function with the last PR, but I realized it would probably make more sense to check `run_step_cmd` in the `run()` function instead. This has no effect on the end-user.

Also, I happened to catch that build flags are printed twice in the `compile()` function, so that is now fixed.