### PR TITLE
Add Language Basics examples 10-13

### DIFF
--- a/examples/01 Language Basics/10 runtime_safety.zig
+++ b/examples/01 Language Basics/10 runtime_safety.zig
@@ -1,3 +1,22 @@
 const std = @import("std");
 
-pub fn main() !void {}
+test "out of bounds, no safety" {
+    @setRuntimeSafety(false);
+    const a = [_]u8{ 1, 2, 3 };
+
+    var index: u8 = 5;
+    _ = &index;
+
+    const b = a[index];
+    _ = b;
+}
+
+test "out of bounds" {
+    const a = [_]u8{ 1, 2, 3 };
+
+    var index: u8 = 5;
+    _ = &index;
+
+    const b = a[index];
+    _ = b;
+}

--- a/examples/01 Language Basics/11 unreachable.zig
+++ b/examples/01 Language Basics/11 unreachable.zig
@@ -1,3 +1,25 @@
 const std = @import("std");
+const expectEqual = std.testing.expectEqual;
 
-pub fn main() !void {}
+fn asciiToUpper(x: u8) u8 {
+    return switch (x) {
+        'a'...'z' => x + 'A' - 'a',
+        'A'...'Z' => x,
+        // Using `unreachable` here tells the compiler that this branch
+        // is impossible, which the optimiser can take advantage of.
+        else => unreachable,
+    };
+}
+
+test "unreachable switch" {
+    try expectEqual('R', asciiToUpper('r'));
+    try expectEqual('C', asciiToUpper('C'));
+}
+
+test "unreachable" {
+    const x: u8 = 5;
+    // Since `unreachable` is of type `noreturn`, it can
+    // coerce to `u8` no problem.
+    const y: u8 = if (x == 4) 3 else unreachable;
+    _ = y;
+}

--- a/examples/01 Language Basics/12 pointers.zig
+++ b/examples/01 Language Basics/12 pointers.zig
@@ -1,3 +1,28 @@
 const std = @import("std");
+const expectEqual = std.testing.expectEqual;
 
-pub fn main() !void {}
+fn addOne(num: *u8) void {
+    num.* += 1;
+}
+
+test "pointers" {
+    var x: u8 = 0;
+    addOne(&x);
+    try expectEqual(1, x);
+}
+
+test "const pointers" {
+    var x: u8 = 1;
+
+    const y = &x;
+    y.* += 1;
+}
+
+// Trying to set a `*T` to 0 is illegal behavior (that will be punished).
+test "arrest this pointer" {
+    var x: u16 = 0;
+    _ = &x;
+
+    var y: *u8 = @ptrFromInt(x);
+    _ = &y;
+}

--- a/examples/01 Language Basics/13 pointer_sized_ints.zig
+++ b/examples/01 Language Basics/13 pointer_sized_ints.zig
@@ -1,3 +1,10 @@
 const std = @import("std");
+const expectEqual = std.testing.expectEqual;
 
-pub fn main() !void {}
+test "usize and isize" {
+    try expectEqual(@sizeOf(usize), @sizeOf(*u8));
+    try expectEqual(@sizeOf(isize), @sizeOf(*u8));
+
+    // This will print '4' on 32-bit machines, and '8' on 64-bit machines.
+    std.debug.print(" OS pointer size: {d} bits ...", .{@sizeOf(*u8)});
+}


### PR DESCRIPTION
This includes the following examples:
- runtime safety
- `unreachable`
- pointers
- pointer-sized ints (`usize` / `isize`)