### PR TITLE
fix: Clear 'b.available_options_list' to remove duplicate project-specific options

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -49,6 +49,7 @@ pub fn build(b: *Build) !void {
     inline for (std.meta.fields(Selection)) |selection| {
         // this fixes `panic: Option 'target' declared twice`
         b.available_options_map.clearRetainingCapacity();
+        b.available_options_list.clearRetainingCapacity();
 
         const example = Example.init(b, @enumFromInt(selection.value));
         const test_run = b.addTest(.{


### PR DESCRIPTION
I noticed earlier that 'zig build --help' showed duplicate '-Doption' flags for each example. Clearing the available options list, like we did with the map, fixes this problem.